### PR TITLE
Close the refresh spinner if the http call fails - Android

### DIFF
--- a/EMS_Android_App/app/src/main/java/com/jia0340/ems_android_app/MainActivity.java
+++ b/EMS_Android_App/app/src/main/java/com/jia0340/ems_android_app/MainActivity.java
@@ -300,7 +300,9 @@ public class MainActivity extends AppCompatActivity implements SearchView.OnQuer
                 // Failed to collect hospital data
                 // TODO: what do we want to happen when it fails?
                 Log.d("MainActivity", t.getMessage());
-                Toast.makeText(MainActivity.this, "Something went wrong...Please try later!", Toast.LENGTH_LONG).show();
+                Toast.makeText(MainActivity.this, R.string.refresh_failed_error, Toast.LENGTH_LONG).show();
+                // Notify the swipe refresher that the data is done refreshing
+                mSwipeContainer.setRefreshing(false);
             }
         });
     }

--- a/EMS_Android_App/app/src/main/res/values/strings.xml
+++ b/EMS_Android_App/app/src/main/res/values/strings.xml
@@ -34,6 +34,7 @@
     <string name="county_region">%s - Region %s</string>
     <string name="regional_coordinating_hospital">Regional Coordinating Hospital %s</string>
     <string name="last_updated">Updated %s</string>
+    <string name="refresh_failed_error">We were unable to refresh the data. Please try again.</string>
 
     <!--filter-->
     <string name="filter_dialog_title">Filter</string>


### PR DESCRIPTION
Close the refresh spinner if the http call fails during the refresh and update the toast error message.