### PR TITLE
Only expand one filter field - iOS

### DIFF
--- a/EMS iOS App/EMS iOS App/UI_Layer/VCs/Filter/FilterSelectorVC.swift
+++ b/EMS iOS App/EMS iOS App/UI_Layer/VCs/Filter/FilterSelectorVC.swift
@@ -86,41 +86,43 @@ class FilterSelectorViewController: UIViewController, UITableViewDataSource, UIT
     }
     
     @IBAction func expandCollapseField(_ sender: UIButton) {
-        var selectedField: UITableView!
-        var heightConstraint: NSLayoutConstraint!
-        var selectedButton: UIButton!
+        let allFields = [specialtyCenterValues, emsRegionValues, countyValues, rchValues]
+        let allHeights = [specialtyCenterHeight, emsRegionHeight, countyHeight, rchHeight]
+        let allButtons = [specialtyCenterButton, emsRegionButton, countyButton, rchButton]
+        var selectedIndex = Int()
         
         switch sender {
         case specialtyCenterButton:
-             selectedField = specialtyCenterValues
-             heightConstraint = specialtyCenterHeight
-             selectedButton = specialtyCenterButton
+            selectedIndex = 0
         case emsRegionButton:
-            selectedField = emsRegionValues
-            heightConstraint = emsRegionHeight
-            selectedButton = emsRegionButton
+            selectedIndex = 1
         case countyButton:
-            selectedField = countyValues
-            heightConstraint = countyHeight
-            selectedButton = countyButton
+            selectedIndex = 2
         case rchButton:
-            selectedField = rchValues
-            heightConstraint = rchHeight
-            selectedButton = rchButton
+            selectedIndex = 3
         default:
-            selectedField = nil
-            heightConstraint = nil
-            selectedButton = nil
+            selectedIndex = -1
         }
         
-        if selectedField?.isHidden == true{
-            selectedField?.isHidden = false
-            heightConstraint?.constant = 300
-            selectedButton.isSelected = true
-        } else if selectedField?.isHidden == false {
-            selectedField?.isHidden = true
-            heightConstraint?.constant = 50
-            selectedButton.isSelected = false
+        if selectedIndex != -1 {
+            if allFields[selectedIndex]?.isHidden == true{
+                for i in 0...3 {
+                    if (i == selectedIndex) {
+                        allFields[i]?.isHidden = false
+                        allHeights[i]?.constant = 300
+                        allButtons[i]?.isSelected = true
+                    } else {
+                        allFields[i]?.isHidden = true
+                        allHeights[i]?.constant = 50
+                        allButtons[i]?.isSelected = false
+                    }
+                }
+                
+            } else {
+                allFields[selectedIndex]?.isHidden = true
+                allHeights[selectedIndex]?.constant = 50
+                allButtons[selectedIndex]?.isSelected = false
+            }
         }
         
     }

--- a/EMS iOS App/EMS iOS App/UI_Layer/VCs/Home/HomeVC.swift
+++ b/EMS iOS App/EMS iOS App/UI_Layer/VCs/Home/HomeVC.swift
@@ -627,41 +627,43 @@ class HomeVC: UIViewController, UITableViewDelegate, UITableViewDataSource, UIGe
     func addFilterCards() {
         // remove all existing filter cards before adding
         self.appliedFiltersView.subviews.forEach({ $0.removeFromSuperview() })
-        
-        var appliedFiltersViewWidth = 0
-        for i in 0...(self.appliedFilters.count - 1) {
-            let filter: FilterIH = self.appliedFilters[i]
-            if let filterCard = Bundle.main.loadNibNamed("FilterCard", owner: nil, options: nil)!.first as? FilterCard {
-                switch filter.field {
-                case .type:
-                    filterCard.valueLabel.text = HospitalType(rawValue: filter.value)!.getHospitalDisplayString()
-                case .emsRegion:
-                    filterCard.valueLabel.text = "Region " + filter.value
-                case .county:
-                    filterCard.valueLabel.text = filter.value
-                case .rch:
-                    filterCard.valueLabel.text = "Regional Coordinating Hospital " + filter.value
-                default:
-                    filterCard.valueLabel.text = filter.value
-                }
-
-                filterCard.removeButton.field = filter.field
-                filterCard.removeButton.value = filter.value
-                filterCard.removeButton.addTarget(self, action: #selector(self.removeFilter(_:)), for: .touchUpInside)
-                self.appliedFiltersView.addArrangedSubview(filterCard)
-                
-                filterCard.translatesAutoresizingMaskIntoConstraints = false
-                let filterCardWidth = filterCard.removeButton.frame.width + filterCard.valueLabel.intrinsicContentSize.width + 12
-                filterCard.widthAnchor.constraint(equalToConstant: filterCardWidth).isActive = true
-                filterCard.heightAnchor.constraint(equalToConstant: 22).isActive = true
-                
-                appliedFiltersViewWidth += Int(filterCardWidth) + 10
-            }
-        }
             
-        self.appliedFiltersView.translatesAutoresizingMaskIntoConstraints = false
-        self.appliedFiltersView.widthAnchor.constraint(equalToConstant: CGFloat(appliedFiltersViewWidth)).isActive = true
-        bottomBarScrollView.contentSize = CGSize(width: appliedFiltersViewWidth, height: 55)
+        if self.appliedFilters.count > 0 {
+            var appliedFiltersViewWidth = 0
+            for i in 0...(self.appliedFilters.count - 1) {
+                let filter: FilterIH = self.appliedFilters[i]
+                if let filterCard = Bundle.main.loadNibNamed("FilterCard", owner: nil, options: nil)!.first as? FilterCard {
+                    switch filter.field {
+                    case .type:
+                        filterCard.valueLabel.text = HospitalType(rawValue: filter.value)!.getHospitalDisplayString()
+                    case .emsRegion:
+                        filterCard.valueLabel.text = "Region " + filter.value
+                    case .county:
+                        filterCard.valueLabel.text = filter.value
+                    case .rch:
+                        filterCard.valueLabel.text = "Regional Coordinating Hospital " + filter.value
+                    default:
+                        filterCard.valueLabel.text = filter.value
+                    }
+
+                    filterCard.removeButton.field = filter.field
+                    filterCard.removeButton.value = filter.value
+                    filterCard.removeButton.addTarget(self, action: #selector(self.removeFilter(_:)), for: .touchUpInside)
+                    self.appliedFiltersView.addArrangedSubview(filterCard)
+                    
+                    filterCard.translatesAutoresizingMaskIntoConstraints = false
+                    let filterCardWidth = filterCard.removeButton.frame.width + filterCard.valueLabel.intrinsicContentSize.width + 12
+                    filterCard.widthAnchor.constraint(equalToConstant: filterCardWidth).isActive = true
+                    filterCard.heightAnchor.constraint(equalToConstant: 22).isActive = true
+                    
+                    appliedFiltersViewWidth += Int(filterCardWidth) + 10
+                }
+            }
+                
+            self.appliedFiltersView.translatesAutoresizingMaskIntoConstraints = false
+            self.appliedFiltersView.widthAnchor.constraint(equalToConstant: CGFloat(appliedFiltersViewWidth)).isActive = true
+            bottomBarScrollView.contentSize = CGSize(width: appliedFiltersViewWidth, height: 55)
+        }
     }
     
     @IBAction func onSortClicked(_ sender: UIBarButtonItem) {


### PR DESCRIPTION
Made it so you can only expand one filter field in the filter menu at a time and fixed bug where app crashed if no filters were selected in menu and hit done